### PR TITLE
add AYUV and YUY2 to supported sink caps

### DIFF
--- a/gstchecksumsink.c
+++ b/gstchecksumsink.c
@@ -59,7 +59,8 @@ static GstStaticPadTemplate gst_cksum_image_sink_sink_template =
 GST_STATIC_PAD_TEMPLATE ("sink",
     GST_PAD_SINK,
     GST_PAD_ALWAYS,
-    GST_STATIC_CAPS (GST_VIDEO_CAPS_MAKE ("{NV12, I420, YV12, P010_10LE}")));
+    GST_STATIC_CAPS (GST_VIDEO_CAPS_MAKE
+        ("{NV12, I420, YV12, AYUV, YUY2, P010_10LE}")));
 
 /* class initialization */
 


### PR DESCRIPTION
Allow AYUV and YUY2 in sink caps